### PR TITLE
Modified sdrutils.hpp and storagehandler.cpp

### DIFF
--- a/sdrutils.hpp
+++ b/sdrutils.hpp
@@ -158,7 +158,7 @@ inline static uint8_t getSensorEventTypeFromPath(const std::string& path)
     return eventType;
 }
 
-static std::string getPathFromSensorNumber(uint8_t sensorNum)
+inline static std::string getPathFromSensorNumber(uint8_t sensorNum)
 {
     std::string path;
 

--- a/sdrutils.hpp
+++ b/sdrutils.hpp
@@ -158,28 +158,18 @@ inline static uint8_t getSensorEventTypeFromPath(const std::string& path)
     return eventType;
 }
 
-inline static std::string getPathFromSensorNumber(uint8_t sensorNum)
+static std::string getPathFromSensorNumber(uint8_t sensorNum)
 {
-    SensorSubTree sensorTree;
     std::string path;
-    if (!getSensorSubtree(sensorTree))
-        return path;
 
-    if (sensorTree.size() < sensorNum)
-    {
+    auto _search = ipmi::sensor::sensors.find(sensorNum);
+
+    if(_search == ipmi::sensor::sensors.end()){
+        phosphor::logging::log<phosphor::logging::level::ERR>("Sensor number invalid.");
         return path;
     }
 
-    uint8_t sensorIndex = sensorNum;
-    for (const auto& sensor : sensorTree)
-    {
-        if (sensorIndex-- == 0)
-        {
-            path = sensor.first;
-            break;
-        }
-    }
-
+    path = _search->second.sensorPath;
     return path;
 }
 #endif // JOURNAL_SEL

--- a/storagehandler.cpp
+++ b/storagehandler.cpp
@@ -1131,6 +1131,10 @@ ipmi_ret_t ipmi_storage_add_sel(ipmi_netfn_t netfn, ipmi_cmd_t cmd,
     if (req->recordType == ipmi::sel::systemEvent)
     {
         std::string sensorPath = getPathFromSensorNumber(req->sensorNum);
+        if(sensorPath.length() == 0){
+            return IPMI_CC_SENSOR_INVALID;
+        }
+
         std::vector<uint8_t> eventData(
             req->eventData, req->eventData + ipmi::sel::systemEventSize);
         bool assert =


### PR DESCRIPTION
Make the function "getPathFromSensorNumber()", which is written in sdrutils.hpp, get path from ipmi::sensor::sensors, rather than dbus services. Besides, add an if statement in ipmi_storage_add_sel(), in storagehandler.cpp, to return error code if user add a sel within an error sensor#.

[Sample.txt](https://github.com/quanta-bmc/phosphor-host-ipmid/files/4273963/Sample.txt)
